### PR TITLE
add logging for bulk insert and quiet mode to avoid printing tracebacks

### DIFF
--- a/mongo_connector/doc_managers/sql.py
+++ b/mongo_connector/doc_managers/sql.py
@@ -4,6 +4,7 @@ import logging
 import unicodedata
 
 import re
+import traceback
 from builtins import chr
 from future.utils import iteritems
 from past.builtins import long, basestring
@@ -128,7 +129,7 @@ def get_document_keys(document):
     return keys
 
 
-def sql_insert(cursor, tableName, document, primary_key):
+def sql_insert(cursor, tableName, document, primary_key, quiet=False):
     creationDate = extract_creation_date(document, primary_key)
     if creationDate is not None:
         document['_creationDate'] = creationDate
@@ -153,8 +154,12 @@ def sql_insert(cursor, tableName, document, primary_key):
 
     try:
         cursor.execute(sql, document)
-    except Exception as e:
-        LOG.error(u"Impossible to upsert the following document %s : %s", document, e)
+
+    except psycopg2.Error:
+        LOG.error(u"Impossible to upsert the following document %s", document)
+
+        if not quiet:
+            LOG.error(u"Traceback:\n%s", traceback.format_exc())
 
 
 def remove_control_chars(s):


### PR DESCRIPTION
There was no exception catching for bulk insert operations, which would end up with mongo-connector crashing and stopping.

With this feature, I'm adding logging of erronous document's primary key and namespace.

I also added an option ``quiet`` (default: ``False``) which, when enable, avoid printing the exception traceback (the feature in pull request #13 can create big requests which is noise in the log file).