### PR TITLE
fix: postgresql_manager: manage update when several doc managers used

### DIFF
--- a/mongo_connector/doc_managers/postgresql_manager.py
+++ b/mongo_connector/doc_managers/postgresql_manager.py
@@ -226,6 +226,8 @@ class DocManager(DocManagerBase):
             self.commit()
 
     def update(self, document_id, update_spec, namespace, timestamp):
+        if not is_mapped(self.mappings, namespace):
+            return
         db, collection = db_and_collection(namespace)
         updated_document = self.get_document_by_id(db, collection, document_id)
         primary_key = self.mappings[db][collection]['pk']


### PR DESCRIPTION
Fixes bug introduced by PR https://github.com/Hopwork/mongo-connector-postgresql/pull/13#event-1290238598 when two doc managers are used as described in PR comment.